### PR TITLE
mockpath name should be the same

### DIFF
--- a/tests/testthat/test-crunch_mean_by.R
+++ b/tests/testthat/test-crunch_mean_by.R
@@ -39,7 +39,7 @@ with_api_fixture <- function(fixture_path, expr) {
 }
 
 # Same tests, but using function
-with_api_fixture("fixture 1", {
+with_api_fixture("fixture1", {
     ds <- crunch::loadDataset(
         "fixture 1",
         project = crunch::projects()[["crunchtestdemo fixtures"]]


### PR DESCRIPTION
used  ds name instead of mockpath, causing a failure if trying to use function based approach (L30+) instead of scripted approach (L31-52) 